### PR TITLE
Fix encoding issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fcall
 Title: Parse Farm Credit Administration Call Report Data into Tidy Data Frames
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Michael", "Thomas", email = "mthomas@ketchbrookanalytics.com", 
            role = c("aut", "cre")),

--- a/R/compare_metadata.R
+++ b/R/compare_metadata.R
@@ -115,8 +115,10 @@ compare_metadata <- function(dir1, dir2) {
 #' `readLines()` and compares the content using the `waldo::compare()` function.
 compare_files_content <- function(filename, dir1, dir2) {
 
-  content1 <- readLines(file.path(dir1, filename), warn = FALSE)
-  content2 <- readLines(file.path(dir2, filename), warn = FALSE)
+  content1 <- readLines(file.path(dir1, filename), warn = FALSE) |>
+    iconv(from = "windows-1252", to = "utf-8")
+  content2 <- readLines(file.path(dir2, filename), warn = FALSE) |>
+    iconv(from = "windows-1252", to = "utf-8")
 
   differences <- waldo::compare(content1, content2, max_diffs = Inf)
 

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -126,9 +126,8 @@ process_metadata_file <- function(file) {
     readLines(file, warn = FALSE) |>
     # Create a single string by concatenating each line
     paste0(collapse = " ") |>
-    # Encode object.
-    # Some characters in files where throwing an error due to its encoding.
-    utf8::utf8_encode() |>
+    # Convert encoding
+    iconv(from = "windows-1252", to = "utf-8") |>
     # Replace tabs with single space.
     # This is necessary because tabs do not separate words as needed.
     stringr::str_replace_all("\\\\t", " ") |>


### PR DESCRIPTION
When encoded to UTF-8, the following files "D_" contained characters in the Description column that produced the symbol "�":

- RC1
- RCB
- RCI1
- RCI2B
- RCI2C
- RCR4
- RCR6

This is because the files seem to use windows-1252 encoding.

The windows-1252 encoding was discovered in different ways:

- `readr::guess_encoding()` placed the higher confidence to this encoding.
- The output of `readLines()` showed characters such as \x92, \x93, \x94, \x96 which, based on context, matched what is described in windows-1252 encoding: https://tablesofstuff.com/encodings/windows-1252/ (search for those characters without "\\" and you will see that they are mostly punctuation symbols, which makes sense).
- Opening the file using VS Code, there is an option to open with different encodings (check the encoding in bottom right corner of the IDE). Changing encodings while the file is open shows how symbols change accordingly.

These changes were applied both to metadata processing and compare metadata functions.

D_* tables in the database have been updated to reflect the changes. Now you should be able to open a connection in excel and properly preview the tables (you will see the corresponding symbol, not the generic "�".





