### PR TITLE
Remove warnings in `append_data()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ BugReports: https://github.com/ketchbrookanalytics/fcall/issues
 Depends: 
     R (>= 3.5.0)
 Imports: 
+    cli,
     DBI,
     dplyr,
     glue,

--- a/R/append_data.R
+++ b/R/append_data.R
@@ -19,7 +19,8 @@ append_single_data <- function(conn, table, data, period) {
   # Inform user
   message(glue::glue("Step 1/2: Removing { period } data from { table }"))
 
-  DBI::dbSendQuery(
+  # Remove any rows that already exist in the table for the period
+  n_dropped <- DBI::dbExecute(
     conn = conn,
     statement = delete_statement
   )

--- a/R/append_data.R
+++ b/R/append_data.R
@@ -16,8 +16,7 @@ append_single_data <- function(conn, table, data, period) {
       where \"DATA_PERIOD\" = '{ period }'
   ")
 
-  # Inform user
-  message(glue::glue("Step 1/2: Removing { period } data from { table }"))
+  cli::cli_inform("Table: { table }")
 
   # Remove any rows that already exist in the table for the period
   n_dropped <- DBI::dbExecute(
@@ -25,8 +24,8 @@ append_single_data <- function(conn, table, data, period) {
     statement = delete_statement
   )
 
-  # Inform user
-  message(glue::glue("Step 2/2: Adding { period } data to { table }"))
+  cli::pluralize("Removed { n_dropped } row{?s}") |>
+    cli::cli_alert_danger()
 
   # Append rows from period
   n_added <- DBI::dbAppendTable(
@@ -36,7 +35,9 @@ append_single_data <- function(conn, table, data, period) {
       dplyr::mutate(DATA_PERIOD = period)
   )
 
-  # Inform user
-  message(glue::glue("{ period } data added to { table }"))
+  cli::pluralize("Added { n_added } row{?s}") |>
+    cli::cli_alert_success()
+
+  cli::cli_rule()
 
 }

--- a/R/append_data.R
+++ b/R/append_data.R
@@ -29,13 +29,11 @@ append_single_data <- function(conn, table, data, period) {
   message(glue::glue("Step 2/2: Adding { period } data to { table }"))
 
   # Append rows from period
-  DBI::dbWriteTable(
+  n_added <- DBI::dbAppendTable(
     conn = conn,
     name = table,
     value = data |>
-      dplyr::mutate(DATA_PERIOD = period),
-    append = TRUE,
-    row.names = FALSE
+      dplyr::mutate(DATA_PERIOD = period)
   )
 
   # Inform user


### PR DESCRIPTION
This PR improves how {DBI} is used to add new data to the database.  It also seeks to improve the console messages displayed to the user indicating the table and corresponding number of rows dropped/added.

This PR also introduces a new **Import** in the `DESCRIPTION` file: {cli}.  Note, however, that {cli} is a dependency of other packages that are already in **Imports**, such as {waldo} and {dplyr}, so we are not introducing any new dependencies beyond what the user is already required to install when installing {fcall}.

Closes #28 